### PR TITLE
Update declared version, application keying and adjust markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,17 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 
   1. Add nerves_ssdp_client to your list of dependencies in `mix.exs`:
 
-        def deps do
-          [{:nerves_ssdp_client, "~> 0.0.1"}]
-        end
+```
+def deps do
+  [{:nerves_ssdp_client, "~> 0.1.0"}]
+end
+```
 
   2. Ensure nerves_ssdp_client is started before your application:
 
-        def application do
-          [applications: [:nerves_ssdp_client]]
-        end
+```
+def application do
+  [extra_applications: [:nerves_ssdp_client]]
+end
+```
 


### PR DESCRIPTION
I've updated the declared version requirement to be `~> 0.1.0` as this is the current release series. The previous `~> 0.0.1` series doesn't seem to exist.

Also, I updated the way in which application dependencies are declared to use the `extra_applications` key to match what `mix new` seems to generate these days. 

Finally, I tweaked the markdown formatting so that these configuration examples are displayed nicely.