### PR TITLE
Fix compilation errors on Elixir 1.15+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /doc
 erl_crash.dump
 *.ez
+.tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.1.4 (2025-11-03)
+
+* Fix compilation errors on Elixir 1.15+
+* Update deprecated `self` syntax to `self()`
+* Fix missing function call parentheses in mix.exs
+* Update minimum Elixir version requirement to ~> 1.4
+
 ## v0.1.3 (2016-07-18)
 
 * Cleaned up documentation

--- a/lib/ssdp_client.ex
+++ b/lib/ssdp_client.ex
@@ -12,7 +12,7 @@ defmodule Nerves.SSDPClient do
 
   @doc false
   def start(_type, _args) do
-    {:ok, self}
+    {:ok, self()}
   end
 
   @doc """
@@ -38,7 +38,7 @@ defmodule Nerves.SSDPClient do
     message = search_msg(target, seconds)
     {:ok, socket} = :gen_udp.open(0, [{:reuseaddr, true}])
     :gen_udp.send(socket, {239, 255, 255, 250}, 1900, message)
-    Process.send_after self, :timeout, timeout_ms
+    Process.send_after self(), :timeout, timeout_ms
     gather_responses_until_timeout(%{}, socket)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,17 +1,17 @@
 defmodule Nerves.SsdpClient.Mixfile do
   use Mix.Project
 
-  @version "0.1.3"
+  @version "0.1.4"
 
   def project do
     [ app: :nerves_ssdp_client,
       version: @version,
-      elixir: "~> 1.2",
+      elixir: "~> 1.4",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps(),
       description: "Client for Simple Service Discovery Protocol",
-      package: package,
+      package: package(),
       name: "Nerves.SSDPClient",
       docs: docs() ]
   end


### PR DESCRIPTION
- Update deprecated `self` syntax to `self()` in lib/ssdp_client.ex
- Fix missing function call parentheses for `package()` in mix.exs
- Update minimum Elixir version requirement from ~> 1.2 to ~> 1.4 (when deprecation warnings started to appear for this syntax)
- Bump version to 0.1.4
- Add .tool-versions to .gitignore

These changes fix compilation errors that occur on Elixir 1.15+ while maintaining backwards compatibility with Elixir 1.4+.